### PR TITLE
Ryzen 5000 illegal instruction

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ opt_var.add_cmake_defines({'NCNN_BUILD_EXAMPLES': false})
 opt_var.add_cmake_defines({'NCNN_INT8': false})
 opt_var.add_cmake_defines({'NCNN_AVX512': false})
 opt_var.add_cmake_defines({'NCNN_AVX512VNNI': false})
+opt_var.add_cmake_defines({'NCNN_XOP': false})
 
 opt_var.add_cmake_defines({'WITH_LAYER_absval': false})
 opt_var.add_cmake_defines({'WITH_LAYER_argmax': false})


### PR DESCRIPTION
I read through #16 and tested different flags and it will not run without disabling this.
Side note, shouldn't there be a way to detect what is available on the building system and use that?