### PR TITLE
build: remove wrong cmake module caused compile error

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,8 @@ else
 endif
 
 if get_option('use_system_ncnn')
-  deps += dependency('ncnn', method: 'cmake', modules: ['glslang', 'ncnn', 'OGLCompiler', 'OSDependent', 'SPIRV'])
+  warning('You must use system NCNN with Vulkan support!')
+  deps += dependency('ncnn', method: 'cmake')
 else
   cmake = import('cmake')
 


### PR DESCRIPTION
'glslang', 'OGLCompiler', 'OSDependent', 'SPIRV' are NOT cmake module,
`glslang`, `OGLCompiler`, `OSDependent`, `SPIRV` are not cmake modules,
we can't check it with cmake dependency checking (this will cause a
dependency-not-found error). If we want to check, we can only get their
Targets.cmake and check if TRAGET exists. As https://github.com/nihui/waifu2x-ncnn-vulkan/blob/53e46c392ece311b3d704132f03d1a3e10276a9b/src/CMakeLists.txt#L66-L78 does,
but we use Meson, so we can't check.

The remaining module is only `ncnn`, but Meson can automatically add it by name，
so remove it together.

Finally, I leave a warning here to remind users of the system NCNN to pay 
attention to the version they are using. (Of course, AFAIK, only Arch Linux does
this)

Signed-off-by: Coelacanthus <coelacanthus@outlook.com>

---
**Edited:** ncnn in subproject can use dependency check because it has the whole project and can generate meson.build from CMakeLists. 
